### PR TITLE
Bugfix jisc logo gets squashed if tagline long

### DIFF
--- a/src/about.html
+++ b/src/about.html
@@ -62,7 +62,7 @@
          
           <div class="header-titles">
 
-            <div class="site-title faux-heading"><a href="http://34.246.160.241.xip.io/">Accessible Organisations</a></div><div class="site-description">Supporting learning providers in creating inclusive teaching and learning experiences</div><!-- .site-description -->
+            <div class="site-title faux-heading"><a href="http://34.246.160.241.xip.io/">Jisc involve</a></div><div class="site-description">Blogs from the Jisc community</div><!-- .site-description -->
           </div><!-- .header-titles -->
 
           <button class="toggle nav-toggle mobile-nav-toggle" data-toggle-target=".menu-modal" data-toggle-body-class="showing-menu-modal" aria-expanded="false" data-set-focus=".close-nav-toggle">

--- a/src/about.html
+++ b/src/about.html
@@ -62,7 +62,7 @@
          
           <div class="header-titles">
 
-            <div class="site-title faux-heading"><a href="http://34.246.160.241.xip.io/">Jisc involve</a></div><div class="site-description">Blogs from the Jisc community</div><!-- .site-description -->
+            <div class="site-title faux-heading"><a href="http://34.246.160.241.xip.io/">Accessible Organisations</a></div><div class="site-description">Supporting learning providers in creating inclusive teaching and learning experiences</div><!-- .site-description -->
           </div><!-- .header-titles -->
 
           <button class="toggle nav-toggle mobile-nav-toggle" data-toggle-target=".menu-modal" data-toggle-body-class="showing-menu-modal" aria-expanded="false" data-set-focus=".close-nav-toggle">

--- a/src/wp-content/themes/twentytwenty-child/style.css
+++ b/src/wp-content/themes/twentytwenty-child/style.css
@@ -3,8 +3,8 @@
  Description:  Twenty Twenty Child Theme to theme Jisc involve
  Author:       Leigh Morris
  Template:     twentytwenty
- Version:      1.0.0
- Date:         2020-04-28
+ Version:      1.0.1
+ Date:         2020-06-26
 */
 
 /*--------------------------------------------------------------
@@ -342,6 +342,7 @@ body caption {
 }
 
 .jisc-logo-link {
+  flex-shrink: 0;
   margin-right: .9rem;
 }
 


### PR DESCRIPTION
https://jiscdev.atlassian.net/browse/DVJ-155

Bug:
![Site header Jisc logo bug](https://user-images.githubusercontent.com/9114600/85861673-9fbc3a80-b7b8-11ea-80e9-0d3971d3704c.png)

Fix:
![Site header Jisc logo fixed](https://user-images.githubusercontent.com/9114600/85861681-a2b72b00-b7b8-11ea-99b8-191fc2e9e32e.png)

